### PR TITLE
Support for handling multiple certs returned in issue certificate call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/ContrailOnlineCAClient.egg-info/
+contrail/security/onlineca/client/test/cli-test-usercert.pem
+contrail/security/onlineca/client/test/test-cli-ca/

--- a/contrail/security/onlineca/client/cli.py
+++ b/contrail/security/onlineca/client/cli.py
@@ -195,8 +195,7 @@ class OnlineCaClientCLI(object):
                 if parsed_args.debug:
                     raise
                 else:
-                    parser.error(e)
-                    raise SystemExit(1)
+                    parser.error(str(e))
         else:
             # func attribute is not defined if no arguments are passed
             parser.print_help()

--- a/contrail/security/onlineca/client/test/test_cli.py
+++ b/contrail/security/onlineca/client/test/test_cli.py
@@ -32,14 +32,14 @@ class OnlineCaClientCLITestCase(unittest.TestCase):
     'Test Certificate Authority command line interface'
     ONLINECA_GET_CERT_URL = os.environ.get(
                                 "TEST_ONLINECA_GET_CERT_URL",
-                                "https://localhost:5000/onlineca/certificate/")
+                                "http://localhost:10443/certificate/")
 
     ONLINECA_GET_TRUSTROOTS_URL = os.environ.get(
                                "TEST_ONLINECA_GET_TRUSTROOTS_URL",
-                               "https://localhost:5000/onlineca/trustroots/")
+                               "http://localhost:10443/trustroots/")
 
     CACERT_DIR = os.path.join(TEST_DIR, "test-cli-ca")
-    USERNAME = os.environ.get("TEST_ONLINECA_GET_CERT_USERNAME", "another")
+    USERNAME = os.environ.get("TEST_ONLINECA_GET_CERT_USERNAME", "testuser")
     PASSWORD = os.environ.get("TEST_ONLINECA_GET_CERT_PASSWORD", "changeme")
     PEM_OUT_FILEPATH = os.path.join(TEST_DIR, "cli-test-usercert.pem")
 

--- a/contrail/security/onlineca/client/test/test_client.py
+++ b/contrail/security/onlineca/client/test/test_client.py
@@ -71,19 +71,19 @@ class OnlineCaClientTestCase(unittest.TestCase):
         onlineca_client = OnlineCaClient()
         onlineca_client.ca_cert_dir = TEST_CA_DIR
 
-        key_pair, cert = onlineca_client.get_certificate(username, password,
+        key_pair, certs = onlineca_client.get_certificate(username, password,
                                 server_url, pem_out_filepath=pem_out_filepath)
         self.assert_(key_pair)
-        self.assert_(cert)
+        self.assert_(certs[0])
 
-        subj = cert.get_subject()
+        subj = certs[0].get_subject()
         self.assert_(subj)
         self.assert_(subj.CN)
 
         log.info("Returned key pair\n%r",
 						crypto.dump_privatekey(crypto.FILETYPE_PEM, key_pair))
         log.info("Returned certificate subject %r", subj)
-        log.info("Returned certificate issuer %r", cert.get_issuer())
+        log.info("Returned certificate issuer %r", certs[0].get_issuer())
 
 
 if __name__ == "__main__":

--- a/contrail/security/onlineca/client/test/test_onlineca_client.cfg
+++ b/contrail/security/onlineca/client/test/test_onlineca_client.cfg
@@ -14,7 +14,7 @@
 [OnlineCaClientTestCase.test01_get_trustroots]
 # Edit these setting for your own environment.  Password can be prompted for
 # from tty by commenting out or removing the password option here
-uri = https://localhost:10443/ca/
+uri = http://localhost:10443/trustroots/
 
 [OnlineCaClientTestCase.test02_get_certificate]
 # Edit these setting for your own environment.  Password can be prompted for
@@ -23,6 +23,6 @@ username: testuser
 password = changeme
 pem_out_filepath = %(here)s/usercert.pem
 
-uri = https://localhost:10443/certificate/
+uri = http://localhost:10443/certificate/
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 setup(
     name =            	'ContrailOnlineCAClient',
-    version =         	'0.4.0',
+    version =         	'0.5.0',
     description =     	'Certificate Authority web service client',
     long_description = 	'''\
 Provides the client interface for an online Certificate Authority web-service.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 setup(
     name =            	'ContrailOnlineCAClient',
-    version =         	'0.5.0',
+    version =         	'0.4.0',
     description =     	'Certificate Authority web service client',
     long_description = 	'''\
 Provides the client interface for an online Certificate Authority web-service.


### PR DESCRIPTION
Added ability to handle multiple intermediate CA certificates returned in issue certificate response from server (corresponds to 0.4.0 `ContrailOnlineCAService` release 